### PR TITLE
Fixed autoplay when changed

### DIFF
--- a/docs/demos.jsx
+++ b/docs/demos.jsx
@@ -3,30 +3,31 @@
 import React from 'react';
 import Slider from '../src/slider';
 
-import SimpleSlider from '../examples/SimpleSlider'
-import SlideChangeHooks from '../examples/SlideChangeHooks'
-import MultipleItems from '../examples/MultipleItems'
-import Responsive from '../examples/Responsive'
-import UnevenSetsInfinite from '../examples/UnevenSetsInfinite'
-import UnevenSetsFinite from '../examples/UnevenSetsFinite'
-import CenterMode from '../examples/CenterMode'
-import FocusOnSelect from '../examples/FocusOnSelect'
-import AutoPlay from '../examples/AutoPlay'
-import PauseOnHover from '../examples/PauseOnHover'
-import Rtl from '../examples/Rtl'
-import VariableWidth from '../examples/VariableWidth'
 import AdaptiveHeight from '../examples/AdaptiveHeight'
-import LazyLoad from '../examples/LazyLoad'
-import Fade from '../examples/Fade'
-import SlickGoTo from '../examples/SlickGoTo'
+import AutoPlay from '../examples/AutoPlay'
+import CenterMode from '../examples/CenterMode'
 import CustomArrows from '../examples/CustomArrows'
-import PreviousNextMethods from '../examples/PreviousNextMethods'
-import DynamicSlides  from '../examples/DynamicSlides'
-import VerticalMode  from '../examples/VerticalMode'
-import SwipeToSlide from '../examples/SwipeToSlide'
-import VerticalSwipeToSlide from '../examples/VerticalSwipeToSlide'
 import CustomPaging from '../examples/CustomPaging'
 import CustomSlides from '../examples/CustomSlides'
+import DynamicSlides  from '../examples/DynamicSlides'
+import Fade from '../examples/Fade'
+import FocusOnSelect from '../examples/FocusOnSelect'
+import LazyLoad from '../examples/LazyLoad'
+import MultipleItems from '../examples/MultipleItems'
+import Pause from '../examples/Pause';
+import PauseOnHover from '../examples/PauseOnHover'
+import PreviousNextMethods from '../examples/PreviousNextMethods'
+import Responsive from '../examples/Responsive'
+import Rtl from '../examples/Rtl'
+import SimpleSlider from '../examples/SimpleSlider'
+import SlickGoTo from '../examples/SlickGoTo'
+import SlideChangeHooks from '../examples/SlideChangeHooks'
+import SwipeToSlide from '../examples/SwipeToSlide'
+import UnevenSetsInfinite from '../examples/UnevenSetsInfinite'
+import UnevenSetsFinite from '../examples/UnevenSetsFinite'
+import VariableWidth from '../examples/VariableWidth'
+import VerticalMode  from '../examples/VerticalMode'
+import VerticalSwipeToSlide from '../examples/VerticalSwipeToSlide'
 
 export default class App extends React.Component {
   render() {
@@ -38,8 +39,9 @@ export default class App extends React.Component {
         <UnevenSetsInfinite />
         <UnevenSetsFinite />
         <CenterMode />
-        <FocusOnSelect />
-        <AutoPlay />
+        <FocusOnSelect /> 
+        <AutoPlay /> 
+        <Pause />
         <PauseOnHover />
         <Rtl />
         <VariableWidth />
@@ -55,7 +57,7 @@ export default class App extends React.Component {
         <DynamicSlides />
         <VerticalMode />
         <SwipeToSlide />
-        <VerticalSwipeToSlide />
+        <VerticalSwipeToSlide />  
 
       </div>
     );

--- a/examples/Pause.js
+++ b/examples/Pause.js
@@ -1,0 +1,43 @@
+import React, { Component } from 'react'
+import Slider from '../src/slider'
+
+export default class Pause extends Component {
+  constructor(props) {
+    super(props);
+    
+    this.state = {
+      paused: false,
+    }
+    this.togglePause = this.togglePause.bind(this);
+  }
+      
+  togglePause() {
+    this.setState({paused: !this.state.paused});
+  }
+
+  render() {
+    const settings = {
+      dots: true,
+      infinite: true,
+      slidesToShow: 3,
+      slidesToScroll: 1,
+      autoplay: !this.state.paused,
+      autoplaySpeed: 2000,
+      paused: this.state.paused,
+    };
+    return (
+      <div>
+        <h2>Pause Auto Play</h2>
+        <Slider {...settings}>
+          <div><h3>1</h3></div>
+          <div><h3>2</h3></div>
+          <div><h3>3</h3></div>
+          <div><h3>4</h3></div>
+          <div><h3>5</h3></div>
+          <div><h3>6</h3></div>
+        </Slider>
+        <button onClick={this.togglePause}>{ this.state.paused ? 'Play' : 'Pause' }</button>
+      </div>
+    );
+  }
+}

--- a/src/inner-slider.js
+++ b/src/inner-slider.js
@@ -96,6 +96,11 @@ export var InnerSlider = createReactClass({
           index: nextProps.children.length - nextProps.slidesToShow,
           currentSlide: this.state.currentSlide
       });
+    } else if (!nextProps.autoplay) {
+      clearTimeout(this.state.autoPlayTimer);
+      this.setState({ autoPlayTimer: null });
+    } else if(nextProps.autoplay) {
+      this.autoPlay(nextProps);
     } else {
       this.update(nextProps);
     }

--- a/src/mixins/helpers.js
+++ b/src/mixins/helpers.js
@@ -332,13 +332,14 @@ var helpers = {
 
     this.slideHandler(nextIndex);
   },
-  autoPlay: function () {
+  autoPlay: function (props) {
+    props = props || this.props;
     if (this.state.autoPlayTimer) {
       clearTimeout(this.state.autoPlayTimer);
     }
-    if (this.props.autoplay) {
+    if (props.autoplay) {
       this.setState({
-        autoPlayTimer: setTimeout(this.play, this.props.autoplaySpeed)
+        autoPlayTimer: setTimeout(this.play, props.autoplaySpeed)
       });
     }
   },


### PR DESCRIPTION
- Prevent additional plays from happening after autoplay prop changed to false.
  - Added conditionals in `inner-slider`'s `willReceiveProps` to listen for the autoplay prop changing. If it catches, it either stops or restarts autoplay without allowing the timer to continue. 
  - autoplay in `mixin/helpers` takes an optional props argument so we can pass in `nextProps`. Without doing that after changing autoplay to true, autoplay sees previous props where autoplay is false.
- If autoplay is changed to true, autoplay works.
- Added another example with a pause button. To help demonstrate how to easily play/pause autoplay (https://github.com/akiran/react-slick/issues/696)
- Imports in `Demos.jsx` are alpha-ordered